### PR TITLE
Fix for changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ Change history for _homebridge-grumptech-volmon_
 - [ISSUE #3](https://github.com/pricemi115/homebridge-grumptech-volmon/issues/3)<br/>
   Added a switch named `Refresh` to the plug-in. Changing the switch to _on_ will initiate a re-scan of the volumes.<br/>
   While the scan is in progress, the user is not permitted to turn the switch off. It will return to the _off_ state<br/>
-  automatically when the scan completes.
+  automatically when the scan completes.<br/>
 ### Fixes & Changes
 - Homebridge Stability: `homebridge` resources were being imported into the deployed script.<br/>
   This could have resulted in stability issues, especially when the plugin is started/restarted.
 - Most debug logging was adjusted to only print when `homebridge` is running in debug mode.
 - Once the plugin is running, accessories for volumes that become dismounted or invisible will no longer be removed on the next scan.<br/>
-  Instead, these accessories will show as `Not reachable` or `Error`.
+  Instead, these accessories will show as `Not reachable` or `Error`.<br/>
 ---
 ## [0.0.7] (Beta 3) - 2021-02-23
 


### PR DESCRIPTION
Some rendering (specifically homebridge-config-ui-x) of changelog.md did not properly show the `Fixes&Changes` section for v0.0.8 as H3